### PR TITLE
fix: Cargo.toml author's email.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "psa-label-enforcer"
 version = "0.1.0"
-authors = ["José Guilherme Vanz <jvanz@jvanz.com>"]
+authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description

Updates the author's email in the Cargo.toml file to the team email address.


