### PR TITLE
Bump v0.1.2 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "psa-label-enforcer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "k8s-openapi",
  "kubewarden-policy-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psa-label-enforcer"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2021"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,29 +4,29 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.1
+version: 0.1.2
 name: psa-label-enforcer
 displayName: PSA Label Enforcer
-createdAt: 2023-05-22T21:21:36.078772788Z
+createdAt: 2023-07-07T18:55:59.967056681Z
 description: Policy to ensure that namespaces have the required PSA labels configuration for deployment in the cluster.
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/psa-label-enforcer
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/psa-label-enforcer:v0.1.1
+  image: ghcr.io/kubewarden/policies/psa-label-enforcer:v0.1.2
 keywords:
 - namespace
 - psa
 - kubewarden
 links:
 - name: policy
-  url: https://github.com/kubwarden/psa-label-enforcer/releases/download/v0.1.1/policy.wasm
+  url: https://github.com/kubwarden/psa-label-enforcer/releases/download/v0.1.2/policy.wasm
 - name: source
   url: https://github.com/kubwarden/psa-label-enforcer
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/psa-label-enforcer:v0.1.1
+  kwctl pull ghcr.io/kubewarden/policies/psa-label-enforcer:v0.1.2
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.2 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.1.2

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
